### PR TITLE
Configurable logger

### DIFF
--- a/fastd/ioctl.go
+++ b/fastd/ioctl.go
@@ -1,9 +1,6 @@
 package fastd
 
-import (
-	"log"
-	"syscall"
-)
+import "syscall"
 
 // nolint: golint
 var (
@@ -16,7 +13,7 @@ var (
 func Ioctl(fd, cmd, ptr uintptr) error {
 	_, _, e := syscall.Syscall(syscall.SYS_IOCTL, fd, cmd, ptr)
 	if e != 0 {
-		log.Printf("errno=%d %s", int(e), e)
+		logger.Errorf("errno=%d %s", int(e), e)
 		return e
 	}
 	return nil

--- a/fastd/logger.go
+++ b/fastd/logger.go
@@ -1,6 +1,9 @@
 package fastd
 
-import "log"
+import (
+	"fmt"
+	"log"
+)
 
 // Logger defines log methods used by this package.
 type Logger interface {
@@ -20,8 +23,22 @@ func SetLogger(l Logger) {
 	}
 }
 
-// stdlogLogger is a thin wrapper around the standard log package.
-type stdlogLogger struct{}
+// log.std is not exposed, so we need to trick a bit to make tests working
+type stdlogOutput func(int, string) error
 
-func (l *stdlogLogger) Infof(format string, a ...interface{})  { log.Printf("INFO - "+format, a...) }
-func (l *stdlogLogger) Errorf(format string, a ...interface{}) { log.Printf("ERROR - "+format, a...) }
+// stdlogLogger is a thin wrapper around the standard log package.
+type stdlogLogger struct {
+	o stdlogOutput // set in tests
+}
+
+func (l *stdlogLogger) Infof(format string, a ...interface{})  { l.out("INFO", format, a...) }
+func (l *stdlogLogger) Errorf(format string, a ...interface{}) { l.out("ERROR", format, a...) }
+
+func (l *stdlogLogger) out(level, format string, a ...interface{}) {
+	msg := fmt.Sprintf(level+" - "+format, a...)
+	if l.o == nil {
+		log.Output(3, msg)
+		return
+	}
+	l.o(4, msg)
+}

--- a/fastd/logger.go
+++ b/fastd/logger.go
@@ -1,0 +1,27 @@
+package fastd
+
+import "log"
+
+// Logger defines log methods used by this package.
+type Logger interface {
+	Infof(format string, a ...interface{})
+	Errorf(format string, a ...interface{})
+}
+
+var logger Logger = &stdlogLogger{}
+
+// SetLogger updates the logger fastd uses. If l is nil, we'll use a
+// thin wrapper around the standard log package.
+func SetLogger(l Logger) {
+	if l == nil {
+		logger = &stdlogLogger{}
+	} else {
+		logger = l
+	}
+}
+
+// stdlogLogger is a thin wrapper around the standard log package.
+type stdlogLogger struct{}
+
+func (l *stdlogLogger) Infof(format string, a ...interface{})  { log.Printf("INFO - "+format, a...) }
+func (l *stdlogLogger) Errorf(format string, a ...interface{}) { log.Printf("ERROR - "+format, a...) }

--- a/fastd/logger_test.go
+++ b/fastd/logger_test.go
@@ -1,0 +1,74 @@
+package fastd
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"runtime"
+	"testing"
+)
+
+// getShortfile returns (file name, line number) of the caller.
+func getShortfile() (string, int) {
+	_, f, l, ok := runtime.Caller(1)
+	if !ok {
+		panic("runtime.Caller should not fail")
+	}
+	return path.Base(f), l
+}
+
+func check(t *testing.T, buf *bytes.Buffer, expected string) {
+	line := buf.String()
+	buf.Reset()
+
+	if actual := string(line); actual != expected {
+		t.Errorf("expected log output to be %q, got %q", expected, actual)
+	}
+}
+
+func TestLogger(t *testing.T) {
+	defer func() {
+		SetLogger(nil) // undo
+	}()
+
+	// log.LstdFlags is a timestamp, and we don't want to mock time here
+	// (which would make this excercise unnecessary complex)
+	var buf bytes.Buffer
+	l := log.New(&buf, "", log.Lshortfile)
+	SetLogger(&stdlogLogger{l.Output})
+
+	{
+		logger.Infof("test %d", 1)
+		fn, ln := getShortfile()
+		check(t, &buf, fmt.Sprintf("%s:%d: INFO - test 1\n", fn, ln-1))
+	}
+	{
+		logger.Errorf("test %d", 2)
+		fn, ln := getShortfile()
+		check(t, &buf, fmt.Sprintf("%s:%d: ERROR - test 2\n", fn, ln-1))
+	}
+}
+
+func TestUpdateStdLogOutput(t *testing.T) {
+	defer func() { // undo changes
+		log.SetOutput(os.Stderr)
+		log.SetFlags(log.LstdFlags)
+	}()
+
+	var buf bytes.Buffer
+	log.SetFlags(log.Lshortfile)
+	log.SetOutput(&buf)
+
+	{
+		logger.Errorf("test %d", 3)
+		fn, ln := getShortfile()
+		check(t, &buf, fmt.Sprintf("%s:%d: ERROR - test 3\n", fn, ln-1))
+	}
+	{
+		logger.Infof("test %d", 4)
+		fn, ln := getShortfile()
+		check(t, &buf, fmt.Sprintf("%s:%d: INFO - test 4\n", fn, ln-1))
+	}
+}

--- a/fastd/peer.go
+++ b/fastd/peer.go
@@ -1,7 +1,6 @@
 package fastd
 
 import (
-	"log"
 	"net"
 	"time"
 
@@ -139,6 +138,6 @@ func (config *AddressConfig) Assign(ifname string) {
 		return
 	}
 	if err := SetAddrPTP(ifname, config.LocalAddr, config.DestAddr); err != nil {
-		log.Printf("Setting addresses for %s failed: %s", ifname, err)
+		logger.Errorf("Setting addresses for %s failed: %s", ifname, err)
 	}
 }

--- a/fastd/server.go
+++ b/fastd/server.go
@@ -2,7 +2,6 @@ package fastd
 
 import (
 	"fmt"
-	"log"
 	"sync"
 	"time"
 
@@ -66,7 +65,7 @@ func NewServer(implName string, config *Config) (srv *Server, err error) {
 			srv.addPeer(peer)
 		} else {
 			// session not established
-			log.Println("destroying unestablished session", peer.Ifname)
+			logger.Infof("destroying unestablished session: %s", peer.Ifname)
 			ifconfig.Destroy(peer.Ifname)
 		}
 	}

--- a/fastd/server_kernel.go
+++ b/fastd/server_kernel.go
@@ -3,7 +3,6 @@ package fastd
 import (
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"os"
 	"strings"
@@ -49,7 +48,7 @@ func NewKernelServer(addresses []Sockaddr) (ServerImpl, error) {
 			return nil, errors.Wrapf(err, "binding to %v failed", address)
 		}
 
-		log.Printf("listening on %s, Port %d", address.IP.String(), address.Port)
+		logger.Infof("listening on %s, Port %d", address.IP.String(), address.Port)
 		srv.addresses = append(srv.addresses, address)
 	}
 
@@ -93,7 +92,7 @@ func (srv *KernelServer) Close() {
 func (srv *KernelServer) Peers() (peers []*Peer) {
 	ifaces, err := net.Interfaces()
 	if err != nil {
-		log.Println("failed to load interfaces:", err)
+		logger.Errorf("failed to load interfaces:", err)
 		return
 	}
 	for _, iface := range ifaces {
@@ -105,9 +104,9 @@ func (srv *KernelServer) Peers() (peers []*Peer) {
 					Remote:    remote,
 					PublicKey: pubkey,
 				})
-				log.Printf("loaded existing session: iface=%s remote=%v pubkey=%x", iface.Name, remote, pubkey)
+				logger.Infof("loaded existing session: iface=%s remote=%v pubkey=%x", iface.Name, remote, pubkey)
 			} else {
-				log.Printf("failed to load session: iface=%s", iface.Name)
+				logger.Errorf("failed to load session: iface=%s", iface.Name)
 			}
 		}
 	}
@@ -130,7 +129,7 @@ func (srv *KernelServer) readPackets() error {
 			data := make([]byte, n)
 			copy(data, buf[:n])
 			if err = srv.read(data); err != nil {
-				log.Println(err)
+				logger.Errorf("%v", err)
 			}
 		case io.EOF:
 			num, e := unix.Poll(pollFds, 60*1000)

--- a/fastd/server_udp.go
+++ b/fastd/server_udp.go
@@ -2,7 +2,6 @@ package fastd
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"sync"
 )
@@ -32,7 +31,7 @@ func NewUDPServer(addresses []Sockaddr) (ServerImpl, error) {
 			Port: int(sa.Port),
 		}
 
-		log.Printf("Listening on %s, Port %d", addr.IP.String(), addr.Port)
+		logger.Infof("Listening on %s, Port %d", addr.IP.String(), addr.Port)
 
 		conn, err := net.ListenUDP("udp", &addr)
 		if err != nil {
@@ -116,7 +115,7 @@ func (srv *UDPServer) findConn(addr Sockaddr) *net.UDPConn {
 func (srv *UDPServer) Write(msg *Message) error {
 	conn := srv.findConn(msg.Src)
 	if conn == nil {
-		log.Println("unable to find connection with local address", msg.Src)
+		logger.Errorf("unable to find connection with local address", msg.Src)
 		return fmt.Errorf("no local connection with address %v", msg.Src)
 	}
 

--- a/fastd/timeout.go
+++ b/fastd/timeout.go
@@ -1,9 +1,6 @@
 package fastd
 
-import (
-	"log"
-	"time"
-)
+import "time"
 
 const (
 	peerCheckInterval = 15 * time.Second
@@ -39,7 +36,7 @@ func (srv *Server) timeoutPeers() {
 
 	for _, peer := range srv.peers {
 		if peer.hasTimeout(now, srv.config.Timeout) {
-			log.Printf("%v timed out ifname=%s", peer.Remote, peer.Ifname)
+			logger.Infof("%v timed out ifname=%s", peer.Remote, peer.Ifname)
 			srv.removePeerLocked(peer)
 
 			if f := srv.config.OnTimeout; f != nil {
@@ -53,7 +50,7 @@ func (srv *Server) timeoutPeers() {
 func (peer *Peer) updateCounter(now time.Time) bool {
 	stats, err := GetStats(peer.Ifname)
 	if err != nil {
-		log.Printf("Unable to get stats for %s: %s", peer.Ifname, err)
+		logger.Errorf("Unable to get stats for %s: %v", peer.Ifname, err)
 		return false
 	}
 


### PR DESCRIPTION
This adds a config option to switch out the logger. The main API is `fastd.SetLogger()` which accepts a `*fastd.Logger`. Such a Logger only needs `Infof()` and `Errorf()` (signatures identical to `log.Printf()`).

I've checked against a few popular loggers, and found these to satisfy `fastd.Logger` without modification:

- [sirupsen/logrus](https://github.com/sirupsen/logrus) - both `*logrus.Entry` and `*logrus.Logger`
- [uber-go/zap](https://github.com/uber-go/zap) - `*zap.SugaredLogger`
- [google/logger](https://github.com/google/logger) - `*logger.Logger`

By default (and when `SetLogger` is called with a nil argument), a thin wrapper around the standard `log` package handles messages as before. This "standard log logger wrapper" injects an `INFO` or `ERROR` string into the message.

I've partitioned existing `log.Printf` calls in the fastd library code into infos and errors, but the utilities in `cmd/` are left untouched.