### PR TITLE
switch libuecc to Go port [WIP]

### DIFF
--- a/fastd/libuecc.go
+++ b/fastd/libuecc.go
@@ -1,26 +1,17 @@
 package fastd
 
-/*
-#cgo pkg-config: libuecc
-#include <unistd.h>
-#include <libuecc/ecc.h>
-
-// Multiplies a point by 8
-static void octuple_point(ecc_25519_work_t *p) {
-	ecc_25519_work_t work;
-	ecc_25519_double(&work, p);
-	ecc_25519_double(&work, &work);
-	ecc_25519_double(p, &work);
-}
-*/
-import "C"
-
 import (
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
+
+	"github.com/digineo/go-libuecc"
 )
+
+func octuplePoint(p *libuecc.Point) *libuecc.Point {
+	return p.Double().Double().Double()
+}
 
 const (
 	// KEYSIZE is the length of a public/private key in bytes
@@ -29,39 +20,39 @@ const (
 
 // KeyPair keeps the secret and public key
 type KeyPair struct {
-	secret [KEYSIZE]byte // the optimized secret
-	public [KEYSIZE]byte
+	secret *libuecc.Int256 // the optimized secret
+	public *libuecc.Int256
 }
 
 // RandomSecret generates a new secret
-func RandomSecret() []byte {
-	var eccSecret C.ecc_int256_t
-	if _, err := rand.Read(eccSecret[:]); err != nil {
+func RandomSecret() *libuecc.Int256 {
+	buf := make([]byte, KEYSIZE)
+	if _, err := rand.Read(buf); err != nil {
 		panic(err)
 	}
 
-	C.ecc_25519_gf_sanitize_secret(&eccSecret, &eccSecret)
-	return eccSecret[:]
+	return libuecc.NewInt256(buf).SanitizeSecret()
 }
 
 // RandomKeypair generates a random keypair
 func RandomKeypair() *KeyPair {
-	return NewKeyPair(RandomSecret())
+	keys := &KeyPair{secret: RandomSecret()}
+	keys.derivePublic()
+	return keys
 }
 
 // NewKeyPair generates a keypair from the given secret
 func NewKeyPair(secret []byte) *KeyPair {
-	keys := &KeyPair{}
 
 	if size := len(secret); size != KEYSIZE {
 		panic(fmt.Sprintf("invalid private key size (%d bytes)", size))
 	}
 
-	copy(keys.secret[:], secret)
+	keys := &KeyPair{secret: libuecc.NewInt256(secret)}
 	keys.derivePublic()
 
 	// Divide the secret key by 8 (for some optimizations)
-	if !divideKey(&keys.secret) {
+	if !divideKey(keys.secret) {
 		panic("invalid private key")
 	}
 
@@ -70,24 +61,11 @@ func NewKeyPair(secret []byte) *KeyPair {
 
 // Public returns a copy of the public key.
 func (keys *KeyPair) Public() []byte {
-	res := make([]byte, KEYSIZE, KEYSIZE)
-	copy(res, keys.public[:])
-	return res
-}
-
-// Derives the public key from the private key and stores it
-func (keys *KeyPair) derivePublic() {
-	var eccWork C.ecc_25519_work_t
-	var eccSecret, eccPublic C.ecc_int256_t
-
-	copy(eccSecret[:], keys.secret[:])
-	C.ecc_25519_scalarmult_base(&eccWork, &eccSecret)
-	C.ecc_25519_store_packed_legacy(&eccPublic, &eccWork)
-	copy(keys.public[:], eccPublic[:])
+	return keys.public.Bytes()
 }
 
 // divides the key by 8
-func divideKey(key *[KEYSIZE]byte) bool {
+func divideKey(key *libuecc.Int256) bool {
 	var c byte
 
 	for i := KEYSIZE - 1; i >= 0; i-- {
@@ -99,21 +77,21 @@ func divideKey(key *[KEYSIZE]byte) bool {
 	return c == 0
 }
 
+// Derives the public key from the private key and stores it
+func (keys *KeyPair) derivePublic() {
+	temp := libuecc.PointBaseLegacy()
+	work := temp.ScalarMult(keys.secret)
+
+	keys.public = work.StorePackedLegacy()
+}
+
 // unpackKey loads a packed legacy key and returns nil in case of an invalid key.
-func unpackKey(key []byte) *C.ecc_25519_work_t {
-	var eccKey C.ecc_int256_t
-	var unpacked C.ecc_25519_work_t
-
-	copy(eccKey[:], key)
-	if C.ecc_25519_load_packed_legacy(&unpacked, &eccKey) != 1 {
+func unpackKey(key []byte) *libuecc.Point {
+	unpacked := libuecc.NewInt256(key).LoadPackedLegacy()
+	if unpacked == nil || unpacked.IsIdentity() {
 		return nil
 	}
-
-	if C.ecc_25519_is_identity(&unpacked) != 0 {
-		return nil
-	}
-
-	return &unpacked
+	return unpacked
 }
 
 func (hs *Handshake) makeSharedKey(initiator bool, ourKey *KeyPair, peerKey []byte) bool {
@@ -123,22 +101,22 @@ func (hs *Handshake) makeSharedKey(initiator bool, ourKey *KeyPair, peerKey []by
 	}
 
 	workXY := unpackKey(hs.peerHandshakeKey)
-	if workXY == nil || C.ecc_25519_is_identity(workXY) != 0 {
+	if workXY == nil {
 		return false
 	}
 
 	var A, B, X, Y []byte
 
 	if initiator {
-		A = ourKey.public[:]
+		A = ourKey.public.Bytes()
 		B = peerKey
-		X = hs.ourHandshakeKey.public[:]
+		X = hs.ourHandshakeKey.public.Bytes()
 		Y = hs.peerHandshakeKey
 	} else {
 		A = peerKey
-		B = ourKey.public[:]
+		B = ourKey.public.Bytes()
 		X = hs.peerHandshakeKey
-		Y = hs.ourHandshakeKey.public[:]
+		Y = hs.ourHandshakeKey.public.Bytes()
 	}
 
 	hash := sha256.New()
@@ -147,7 +125,7 @@ func (hs *Handshake) makeSharedKey(initiator bool, ourKey *KeyPair, peerKey []by
 	hash.Write(B)
 	hash.Write(A)
 
-	var d, e, s C.ecc_int256_t
+	var d, e libuecc.Int256
 	hashSum := hash.Sum(nil)
 
 	copy(d[:], hashSum[:len(hashSum)/2])
@@ -156,24 +134,23 @@ func (hs *Handshake) makeSharedKey(initiator bool, ourKey *KeyPair, peerKey []by
 	d[15] |= 0x80
 	e[15] |= 0x80
 
-	var work C.ecc_25519_work_t
-	var eccOurKeySecret, eccHandshakeKeySecret, eccSigma C.ecc_int256_t
+	var work *libuecc.Point
+	var eccOurKeySecret, eccHandshakeKeySecret libuecc.Int256
 
 	copy(eccOurKeySecret[:], ourKey.secret[:])
 	copy(eccHandshakeKeySecret[:], hs.ourHandshakeKey.secret[:])
 
+	var s *libuecc.Int256
 	if initiator {
-		var da C.ecc_int256_t
-		C.ecc_25519_gf_mult(&da, &d, &eccOurKeySecret)
-		C.ecc_25519_gf_add(&s, &da, &eccHandshakeKeySecret)
-		C.ecc_25519_scalarmult_bits(&work, &e, eccPeerKey, 128)
+		da := d.GfMult(&eccOurKeySecret)
+		s = da.GfAdd(&eccHandshakeKeySecret)
+		work = eccPeerKey.ScalarMultBits(&e, 128)
 	} else {
-		var eb C.ecc_int256_t
-		C.ecc_25519_gf_mult(&eb, &e, &eccOurKeySecret)
-		C.ecc_25519_gf_add(&s, &eb, &eccHandshakeKeySecret)
-		C.ecc_25519_scalarmult_bits(&work, &d, eccPeerKey, 128)
+		eb := e.GfMult(&eccOurKeySecret)
+		s = eb.GfAdd(&eccHandshakeKeySecret)
+		work = eccPeerKey.ScalarMultBits(&d, 128)
 	}
-	C.ecc_25519_add(&work, workXY, &work)
+	work = workXY.Add(work)
 
 	/*
 	  Both our secret keys have been divided by 8 before, so we multiply
@@ -184,18 +161,16 @@ func (hs *Handshake) makeSharedKey(initiator bool, ourKey *KeyPair, peerKey []by
 	  be in the private keys anyways, the reduction modulo the subgroup order (in ecc_25519_gf_*)
 	  will only preserve it if the point actually lies on our subgroup.
 	*/
-	C.octuple_point(&work)
+	work = octuplePoint(work)
+	work = work.ScalarMult(s)
 
-	C.ecc_25519_scalarmult(&work, &s, &work)
-
-	if C.ecc_25519_is_identity(&work) != 0 {
+	if work.IsIdentity() {
 		return false
 	}
 
 	// Store sigma
-	C.ecc_25519_store_packed_legacy(&eccSigma, &work)
-	var sigma [KEYSIZE]byte
-	copy(sigma[:], eccSigma[:])
+	eccSigma := work.StorePackedLegacy()
+	sigma := eccSigma.Bytes()
 
 	// Derive shared key
 	hs.sharedKey = deriveKey(A, B, X, Y, sigma[:])


### PR DESCRIPTION
This switches libuecc with a Go port (see github.com/digineo/go-libuecc).

Currently there's a discrepancy in the generated data when using `(*Handshake).makeSharedKey()`: the result of `unpackKey()` using the C library is different from the one using the Go port.

Here's a work-in-progress dump of the key material:

<details>
<summary>generated with C code</summary>

```


initiator false
ourkey.secret      d0e1515e87bbf8fb6b2db222d00c2f649d3d9e3d7b0bc2b636ffc5c9f71e8e09
ourkey.public      346a11a8bd8fcedfcde2e19c996b6e4497d0dafc3f5af7096c915bd0f9fe4fe9
peerKey            83369beddca777585167520fb54a7fb059102bf4e0a46dd5fb1c633d83db77a2
hs.peerHsKey       b4dbdb0c05dd28204534fa27c5afca4dcda5397d833e3064f7a7281b249dc7c7
hs.ourHsKey.secret 74a7ed1bc776b25b7cf9dd3a8d359dd38233d4c335e12f96a858b933f639da0e
hs.ourHsKey.public ee9fd586a4b62afd0f9b2ec9ee7b926d35e97cf17c956d4654bfbca69b24d499
	eccPeerKey.X=[58 26 ad f5 5c 58 75 58 73 55 94 bf 4f 03 63 18 a9 6b f1 8d 6c 6c 6a 79 3e 24 1d ab 61 9d b4 72]
	          .Y=[d0 ce 26 29 0c 1f fd 9f 7a a7 bc 10 57 c9 c6 92 04 2f 4c ef 0e a6 04 a1 fe 46 c2 a7 b0 75 a1 88]
	          .Z=[01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00]
	          .T=[95 ac 50 dc e7 23 fa c1 28 ce ae 26 25 8c 2c 6b b3 7e cc 40 b9 0f c5 f4 65 5c 75 f0 9d 28 b8 62]
	workXY.X=[77 3c 1d 9f 36 46 bc ce d7 9f 7b bc ff fa 80 ea 83 d8 09 75 6e 10 ca 93 30 64 ce ac 46 32 15 34]
	      .Y=[13 24 b2 0e 1e 39 7e f1 d6 6c f6 70 9b 15 13 0b dd 03 b7 43 00 48 b5 8e 13 ba 6f c0 54 c8 a0 11]
	      .Z=[01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00]
	      .T=[20 c3 38 fb 4c 47 b6 ab db ed 55 3b b4 7e bf 18 d8 01 0a cc 21 3e 9e 9e f4 9c 55 b3 97 cc af 59]
	A 83369beddca777585167520fb54a7fb059102bf4e0a46dd5fb1c633d83db77a2
	B 346a11a8bd8fcedfcde2e19c996b6e4497d0dafc3f5af7096c915bd0f9fe4fe9
	X b4dbdb0c05dd28204534fa27c5afca4dcda5397d833e3064f7a7281b249dc7c7
	Y ee9fd586a4b62afd0f9b2ec9ee7b926d35e97cf17c956d4654bfbca69b24d499
	hashSum e11e23e56b622f75f612c994ee3d2a82ce9a4dea158677c08cfd15573c748e29
	d e11e23e56b622f75f612c994ee3d2a8200000000000000000000000000000000
	e ce9a4dea158677c08cfd15573c748ea900000000000000000000000000000000
	eb fb6eccb49c49e6f0e32f83e04c149034705c3dcde5b6e76e9d71e51ed7a3fe05
	s 5ceaaf2d7e23aba436c658beb8430c1df38f11911b98170546ca9e52cdddd824
	work.X=[77 c4 c0 78 af 25 9f 0c 77 a3 40 b6 9c a8 bd 60 75 a1 96 94 e4 64 16 29 6d 4b 9a 59 71 96 f3 4c]
	    .Y=[81 53 ea 2b 1f 14 67 32 5c 08 77 b5 23 4c be 59 b3 2c b7 36 88 e4 be a7 51 84 36 05 f5 19 54 5f]
	    .Z=[2a ec 61 79 7d 65 88 a5 96 85 c6 8b a8 aa 4e 5b b0 53 5e f5 73 1c d9 1d ed 14 74 0c 2d d0 08 7e]
	    .T=[b0 3d 04 65 db 49 49 7d 5f e9 b4 c0 b3 a0 d1 31 88 a3 ed bd de a4 11 67 98 d7 03 29 22 e2 9d 7a]
	work.X=[d2 56 ad e1 38 9c 99 3e d4 61 67 9d 37 59 f7 c0 25 d3 02 60 d7 e6 ce 2e a4 c9 bd 3e 50 f9 f1 76]
	    .Y=[44 6c 0c e5 61 48 16 7f 54 a5 5d aa 90 b9 e8 17 c3 b8 c4 ca f0 21 f7 c6 8a 87 a9 17 e7 86 ac 0d]
	    .Z=[23 4b 90 e0 34 90 70 55 a5 9d 64 a7 14 ce 7d 0d b7 15 19 f3 44 12 b4 cc c3 b6 95 cb 34 b8 fc 0d]
	    .T=[8b 46 c3 c5 72 79 36 04 36 db f3 33 e6 8e 94 b0 53 f9 29 d2 c9 8c f5 77 35 59 5b 02 de 6b a9 75]
	work.X=[e9 c3 c6 1e 70 60 e2 88 9e 69 59 c4 03 51 25 b3 90 2f 27 b1 67 26 a7 f6 67 06 b6 50 83 10 5c 54]
	    .Y=[68 b2 18 98 46 dd 1a 25 65 8e 73 d1 d3 22 2c e6 7f b0 18 9f eb 90 df bd 89 9c 53 f5 7e 8d 16 64]
	    .Z=[fa c7 90 68 50 07 ef 54 88 e0 08 76 70 50 45 9e a0 93 11 23 51 3f 17 56 ae e6 82 d0 bf d2 de 79]
	    .T=[5e 21 95 0b d3 e5 f0 b7 27 58 03 3d b3 f5 ca 53 ba 4b ab 89 59 37 c4 9b 45 b9 61 de 26 23 df 4c]
	sigma 1c56f0a645760665b5394140265cd88310e8588426aa51f6cb9db32e36ca881b
	sharedKey 98a840f7d3845024b6cae090d86eeb72e2607a84ce8ee6ac25639d27e9696596


initiator true
ourkey.secret      db0467fc77e82d9d858a8c738675148c6caa2928ee9a6ecd6f9c4d70a5313409
ourkey.public      fc734153be59d7a44041e71b39bfa6652fb5208351efa8cfd4213f7c8588b14d
peerKey            346a11a8bd8fcedfcde2e19c996b6e4497d0dafc3f5af7096c915bd0f9fe4fe9
hs.peerHsKey       3bac2ada2fbfa1ea75b2cb214490d5d718f1bbe5b226184488c07cf1a551e8d9
hs.ourHsKey.secret 20406080a0c0e00021416181a1c1e10122426282a2c2e20223436383a3c3e30b
hs.ourHsKey.public 41c6ef88f136a75cbed202ecc6242e0dbbc916147306dd998a3f94e01b39b051
	eccPeerKey.X=[44 45 00 3a 02 df ac 69 3a db a0 d2 48 92 40 04 b4 e4 db e4 c1 85 89 dd e6 42 36 7b 18 5a 37 50]
	          .Y=[31 53 57 22 88 f3 2b 91 59 e4 88 39 19 ec bb 73 8c 23 93 32 ef 44 55 dc 99 97 3a 4e 9f 4f b8 19]
	          .Z=[01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00]
	          .T=[d5 f9 4a 28 c0 0e 8e a2 c6 26 10 99 4a 8e 7d d2 47 84 c6 0c c5 1b d4 b2 71 06 e3 60 b8 2c 48 25]
	workXY.X=[6c 50 7e 1e 4b a3 d3 18 62 0f f7 3b d5 8d ae d5 55 05 53 59 62 4c 7b d9 3d 25 b5 96 c6 3e 6a 5e]
	      .Y=[a0 87 f4 d3 6f 16 7e 3e 2c e1 c0 54 26 90 6c d2 ae 0f f7 75 29 61 e6 8f 36 0a f7 be a0 f0 ac 94]
	      .Z=[01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00]
	      .T=[44 a2 3b c1 6d e5 85 26 a8 33 81 32 0c e5 78 08 ac 59 86 96 c6 81 e8 e7 b7 85 9e cb 6c 27 42 32]
	A fc734153be59d7a44041e71b39bfa6652fb5208351efa8cfd4213f7c8588b14d
	B 346a11a8bd8fcedfcde2e19c996b6e4497d0dafc3f5af7096c915bd0f9fe4fe9
	X 41c6ef88f136a75cbed202ecc6242e0dbbc916147306dd998a3f94e01b39b051
	Y 3bac2ada2fbfa1ea75b2cb214490d5d718f1bbe5b226184488c07cf1a551e8d9
	hashSum 5cd981f2cefe909e2232243a6c175f39ff7ac74054d58ad70529c8f3751eba6e
	d 5cd981f2cefe909e2232243a6c175fb900000000000000000000000000000000
	e ff7ac74054d58ad70529c8f3751ebaee00000000000000000000000000000000
	da 601a4fe3a8175086d799bbcacb3c2204d74aae0002cf85ea4cc0690c86b6f50c
	s 6d2ea5c0633b43dfce7714ef4bf8e21af98c1083a49168ed6f03cd8f297ad928
	work.X=[38 a6 16 7f 1a cf 1e 68 7b d3 26 94 58 32 69 bd dd bf 23 a4 5c 3c 62 b0 f5 98 1b 92 fc 28 18 08]
	    .Y=[eb f7 a5 e1 f6 04 28 66 e3 f2 be 4a 5c 9d 1d ab fd 8f 28 e0 19 77 e1 b8 0c 0e 5c 38 8b 45 af 55]
	    .Z=[90 ec 76 c5 de 61 14 fe 37 91 68 72 18 eb b7 40 92 06 58 c1 20 ee d7 f5 e0 a8 a5 d1 06 f1 0f 66]
	    .T=[dd 37 fa 95 fa ea 00 d0 23 02 e5 6e bb d4 9d 84 03 e9 9c 3e 8a 5f 5d c2 25 b9 5d 2e 43 16 97 67]
	work.X=[85 60 13 b1 d0 8f 0b d1 53 df 8c 75 48 7c 1e 7c 91 70 a8 46 a6 a8 d7 c3 df ce 1b 19 2f f4 b9 61]
	    .Y=[d0 7c 20 e3 63 b4 fc 57 85 65 a1 d4 5f d4 31 8f c4 d0 1d 60 0d c8 5d 9f 13 84 8a e8 88 3d 4b 45]
	    .Z=[80 cf 9c 22 a2 58 13 b6 92 42 72 28 b5 72 ee 38 3a b2 5b 65 d4 b4 13 c3 60 17 75 46 ad 11 97 08]
	    .T=[ae 04 b9 ef bc c4 ab 24 ec cf 0f 78 e2 22 49 7a 93 9d f1 3f 4a 6e ae 0c 9c 06 0e 61 ad 2a e5 17]
	work.X=[e4 6c 09 ae 3d b9 7c db 38 f9 73 2b b1 18 3b bf 81 9b 18 97 ed 92 5b 2e f0 08 a4 dd 9f 0e 46 5a]
	    .Y=[3d fd 73 3d 2e 05 ef b5 4b 6d 0d 0f 61 42 b1 c9 05 e1 2d 9c 4e 6c 8f 86 0e a5 89 7f 9e 7a ba 6c]
	    .Z=[07 71 fa e4 8e 73 cf c3 97 66 2a 66 9a 37 84 bd 45 72 3a f1 e7 56 77 30 d5 72 b0 25 50 fd fc 08]
	    .T=[8a 3e ae a4 ce f2 c6 a1 02 72 e5 04 5c e5 8e 4f 05 51 f1 32 62 4b dd 98 28 6e 23 ae 73 15 c9 25]
	sigma eac6e20a524fab49c949ead3647c2be62af70297a62893084b6b2d9976b2d67d
	sharedKey d5d652897baf38d7947921e167288a0fb2e8c32edb5f9efd56e34aa574d5fac9
```

</details>


<details>
<summary>generated with Go code</summary>

```


initiator false
ourkey.secret      d0e1515e87bbf8fb6b2db222d00c2f649d3d9e3d7b0bc2b636ffc5c9f71e8e09
ourkey.public      346a11a8bd8fcedfcde2e19c996b6e4497d0dafc3f5af7096c915bd0f9fe4fe9
peerKey            83369beddca777585167520fb54a7fb059102bf4e0a46dd5fb1c633d83db77a2
hs.peerHsKey       b4dbdb0c05dd28204534fa27c5afca4dcda5397d833e3064f7a7281b249dc7c7
hs.ourHsKey.secret 74a7ed1bc776b25b7cf9dd3a8d359dd38233d4c335e12f96a858b933f639da0e
hs.ourHsKey.public ee9fd586a4b62afd0f9b2ec9ee7b926d35e97cf17c956d4654bfbca69b24d499
	eccPeerKey.X=[83 36 9b ed dc a7 77 58 51 67 52 0f b5 4a 7f b0 59 10 2b f4 e0 a4 6d d5 fb 1c 63 3d 83 db 77 22]
	          .Y=[d0 ce 26 29 0c 1f fd 9f 7a a7 bc 10 57 c9 c6 92 04 2f 4c ef 0e a6 04 a1 fe 46 c2 a7 b0 75 a1 88]
	          .Z=[01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00]
	          .T=[20 b0 2f 2a 63 b1 6c 8c a1 46 4f ec 6f 0b 8a 14 53 a8 7e 36 ee 4a c3 e6 7e 02 50 04 3f 7d fb 11]
	workXY.X=[b4 db db 0c 05 dd 28 20 45 34 fa 27 c5 af ca 4d cd a5 39 7d 83 3e 30 64 f7 a7 28 1b 24 9d c7 47]
	      .Y=[13 24 b2 0e 1e 39 7e f1 d6 6c f6 70 9b 15 13 0b dd 03 b7 43 00 48 b5 8e 13 ba 6f c0 54 c8 a0 11]
	      .Z=[01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00]
	      .T=[7f 7c 5b 5f 42 f9 fd db 2e 84 4e 7e 72 8f 2e 52 00 3a 17 68 e5 7a 1d f9 1f 7a 09 28 4a 5f 14 72]
	A 83369beddca777585167520fb54a7fb059102bf4e0a46dd5fb1c633d83db77a2
	B 346a11a8bd8fcedfcde2e19c996b6e4497d0dafc3f5af7096c915bd0f9fe4fe9
	X b4dbdb0c05dd28204534fa27c5afca4dcda5397d833e3064f7a7281b249dc7c7
	Y ee9fd586a4b62afd0f9b2ec9ee7b926d35e97cf17c956d4654bfbca69b24d499
	hashSum e11e23e56b622f75f612c994ee3d2a82ce9a4dea158677c08cfd15573c748e29
	d e11e23e56b622f75f612c994ee3d2a8200000000000000000000000000000000
	e ce9a4dea158677c08cfd15573c748ea900000000000000000000000000000000
	eb fb6eccb49c49e6f0e32f83e04c149034705c3dcde5b6e76e9d71e51ed7a3fe05
	s 5ceaaf2d7e23aba436c658beb8430c1df38f11911b98170546ca9e52cdddd824
	work.X=[d3 e1 f8 75 fc a5 2a 56 de 4c f1 ed ae 13 ad 67 94 49 bb e4 f9 5b 82 8d 51 d7 02 c6 e9 9f d8 0e]
	    .Y=[cf 3a 19 bb 6f 1d 2c 37 77 7b f0 94 c6 ae 3d 76 40 6d 06 11 8e b6 62 6b dd b6 71 48 36 ca b2 02]
	    .Z=[04 e7 ac 67 31 67 21 06 31 b1 0e c4 83 47 d4 7c 0d 71 a8 2b 07 3f 93 fa 51 1a f6 29 37 1d c6 0d]
	    .T=[29 5c 52 96 0e 17 29 ce e6 29 cf d0 ab 1e 2b e4 3b 8e cf cc 0a db f9 43 99 a5 86 14 8b a0 1d 01]
	work.X=[9f 96 3f 84 c0 99 91 27 a6 fc f7 5f a9 27 3d cd 67 57 e6 53 c1 ec 70 e4 2a f0 83 7b 76 9a 31 1f]
	    .Y=[24 18 f0 3e 7e 40 d3 2f a8 e5 79 ae bf a7 c6 7f 65 92 90 17 a0 d5 fe 90 ef 8d 1f a6 77 2c 6a 4d]
	    .Z=[58 2e de 8a 46 b4 71 de c0 27 28 49 1b 55 86 17 fc c7 21 72 a0 31 4b 66 75 fd 43 a9 f7 1e 65 51]
	    .T=[89 bc e8 87 76 e3 6b a3 89 6a 53 62 d0 a7 a6 78 14 6d 30 fd e2 d6 e7 d1 1a 54 2a 68 10 eb 0a 3e]
	work.X=[96 aa 29 15 da 75 b1 ed 04 21 2e ec fe 60 31 85 9f 35 63 3d 08 bd 74 4d ca b2 e5 a6 36 ac db 1e]
	    .Y=[50 39 69 7d c7 23 fd 79 41 24 ae b1 46 01 45 29 4c fc d5 b7 cb 4f 6e 93 10 6d aa 2e d8 a0 bb 30]
	    .Z=[d0 1f bc cd 80 70 7b 46 80 c6 39 98 f0 99 40 1f ab e1 da b2 dc 3e 61 96 06 0e d1 ac 19 13 44 77]
	    .T=[7d 59 8b bd ad 77 46 42 20 c5 48 cf fe 08 48 d8 a1 e4 c1 27 ee 58 11 b8 f5 25 17 35 e2 22 8d 7d]
	sigma 1c56f0a645760665b5394140265cd88310e8588426aa51f6cb9db32e36ca881b
	sharedKey 98a840f7d3845024b6cae090d86eeb72e2607a84ce8ee6ac25639d27e9696596


initiator true
ourkey.secret      db0467fc77e82d9d858a8c738675148c6caa2928ee9a6ecd6f9c4d70a5313409
ourkey.public      fc734153be59d7a44041e71b39bfa6652fb5208351efa8cfd4213f7c8588b14d
peerKey            346a11a8bd8fcedfcde2e19c996b6e4497d0dafc3f5af7096c915bd0f9fe4fe9
hs.peerHsKey       3bac2ada2fbfa1ea75b2cb214490d5d718f1bbe5b226184488c07cf1a551e8d9
hs.ourHsKey.secret 20406080a0c0e00021416181a1c1e10122426282a2c2e20223436383a3c3e30b
hs.ourHsKey.public 41c6ef88f136a75cbed202ecc6242e0dbbc916147306dd998a3f94e01b39b051
	eccPeerKey.X=[34 6a 11 a8 bd 8f ce df cd e2 e1 9c 99 6b 6e 44 97 d0 da fc 3f 5a f7 09 6c 91 5b d0 f9 fe 4f 69]
	          .Y=[31 53 57 22 88 f3 2b 91 59 e4 88 39 19 ec bb 73 8c 23 93 32 ef 44 55 dc 99 97 3a 4e 9f 4f b8 19]
	          .Z=[01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00]
	          .T=[5d 8f 1c fb 0d 54 d1 7d e5 f1 12 32 c0 54 cc a5 b6 94 0c c6 47 95 c6 d6 e5 15 c2 ed 63 b7 cc 09]
	workXY.X=[3b ac 2a da 2f bf a1 ea 75 b2 cb 21 44 90 d5 d7 18 f1 bb e5 b2 26 18 44 88 c0 7c f1 a5 51 e8 59]
	      .Y=[a0 87 f4 d3 6f 16 7e 3e 2c e1 c0 54 26 90 6c d2 ae 0f f7 75 29 61 e6 8f 36 0a f7 be a0 f0 ac 94]
	      .Z=[01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00]
	      .T=[d0 7a 54 a6 0f 42 fa af 20 d6 7d 01 d8 ec bf 16 b8 b4 0a 83 ea 44 34 a0 7a d3 7e d7 54 2f 16 21]
	A fc734153be59d7a44041e71b39bfa6652fb5208351efa8cfd4213f7c8588b14d
	B 346a11a8bd8fcedfcde2e19c996b6e4497d0dafc3f5af7096c915bd0f9fe4fe9
	X 41c6ef88f136a75cbed202ecc6242e0dbbc916147306dd998a3f94e01b39b051
	Y 3bac2ada2fbfa1ea75b2cb214490d5d718f1bbe5b226184488c07cf1a551e8d9
	hashSum 5cd981f2cefe909e2232243a6c175f39ff7ac74054d58ad70529c8f3751eba6e
	d 5cd981f2cefe909e2232243a6c175fb900000000000000000000000000000000
	e ff7ac74054d58ad70529c8f3751ebaee00000000000000000000000000000000
	da 601a4fe3a8175086d799bbcacb3c2204d74aae0002cf85ea4cc0690c86b6f50c
	s 6d2ea5c0633b43dfce7714ef4bf8e21af98c1083a49168ed6f03cd8f297ad928
	work.X=[72 14 d6 48 de af e3 9a 85 0d b7 68 5a f0 b8 d3 17 e8 f8 b8 e0 68 87 1a 29 3a 81 25 c0 41 83 08]
	    .Y=[be 10 4a ea 93 f0 70 44 e1 a9 63 d5 d7 37 f0 e8 6e 21 ef 87 85 75 03 bf 40 4a 52 de da cb 05 7f]
	    .Z=[de 8b 02 7f 8d a7 f2 8d d5 0f f2 e9 85 b3 11 c4 4f 06 4d 95 ab c8 e9 85 d2 78 22 c6 ef ef 23 46]
	    .T=[54 27 33 6d fc b5 ff 72 5a 7c 29 9a 40 1a 99 f4 e7 41 b9 03 b8 f4 e1 d2 b8 e4 d6 85 fa 6a ac 5f]
	work.X=[29 29 22 20 b5 ee b5 c1 af d9 56 b1 ee ce 13 a4 ae 25 83 83 50 10 93 83 fd 0d 44 41 6c cf f8 22]
	    .Y=[1b af 01 aa d8 aa bb c3 44 e5 ae b6 19 5d 11 eb 45 9b 39 d1 bc 17 df b7 53 58 7e e2 5c 77 3e 35]
	    .Z=[c0 b6 1d c9 62 ca 3d 32 bc 6a fe 33 60 f4 08 67 76 b6 a9 12 ae 1b 5a d8 e4 4c 83 a5 39 92 e1 64]
	    .T=[e3 14 b4 64 54 34 2b bd b2 7f 1c fa bd cd 75 df 12 c7 92 43 42 cc fb f1 6d a4 ba c8 5e e6 14 22]
	work.X=[15 ad b6 df a8 63 4e cd 01 48 42 9d 33 d9 d7 ce 41 68 79 a9 d0 fc c9 a4 ab d9 6b b5 9e 6c 6e 32]
	    .Y=[23 af 23 45 24 8e 57 e8 90 a2 be 11 9f ea c4 58 36 ed f1 f1 bd 92 0b 7e c1 47 21 ee a9 2e f2 0f]
	    .Z=[30 66 fc 2b b8 71 f7 60 d7 ae 45 72 47 49 df 76 09 d1 49 d4 9a 5e e4 55 58 43 6b df 9b 7d e3 5b]
	    .T=[4d 6c 7a 9d 8b 38 68 29 9a 2e 88 a8 11 05 d8 97 c8 0b 0d b8 70 49 5e 94 84 a1 1e e2 84 73 ff 3d]
	sigma eac6e20a524fab49c949ead3647c2be62af70297a62893084b6b2d9976b2d67d
	sharedKey d5d652897baf38d7947921e167288a0fb2e8c32edb5f9efd56e34aa574d5fac9
```

</details>

The tests are green, but I'm not sure yet whether (and how) significant this differece is...